### PR TITLE
fix: generate GraalVM native image configuration

### DIFF
--- a/rxjava2/build.gradle
+++ b/rxjava2/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "io.micronaut.build.internal.module"
 }
 dependencies {
+    annotationProcessor "io.micronaut:micronaut-graal:$micronautVersion"
     api "io.micronaut:micronaut-runtime:$micronautVersion"
     api "io.reactivex.rxjava2:rxjava:$rxJava2Version"
 }


### PR DESCRIPTION
The TypeHint annotation is used to create hints for the GraalVM native
image compiler in order to make certain classes available for
reflection. The configuration for the micronaut-graal annotation
processor was missing, which causes the GraalVM configuration to be
absent.

This change adds the micronaut-graal annotation processor to the build
configuration in order to generate the GraalVM configuration and include
it in the resulting artifacts.

This fixes https://github.com/micronaut-projects/micronaut-rxjava2/issues/32