### PR TITLE
Allow closing RxHttpClients

### DIFF
--- a/rxjava2-http-client/src/main/java/io/micronaut/rxjava2/http/client/BridgedRxHttpClient.java
+++ b/rxjava2-http-client/src/main/java/io/micronaut/rxjava2/http/client/BridgedRxHttpClient.java
@@ -109,4 +109,22 @@ class BridgedRxHttpClient implements RxHttpClient {
         return httpClient.isRunning();
     }
 
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+
+    @Override
+    @NonNull
+    public HttpClient start() {
+        httpClient.start();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public HttpClient stop() {
+        httpClient.stop();
+        return this;
+    }
 }

--- a/rxjava2-http-client/src/test/groovy/io/micronaut/rxjava2/http/client/RxClientCloseSpec.groovy
+++ b/rxjava2-http-client/src/test/groovy/io/micronaut/rxjava2/http/client/RxClientCloseSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.rxjava2.http.client
+
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class RxClientCloseSpec extends Specification {
+    def "confirm RxHttpClient can be stopped"() {
+        given:
+        def client = RxHttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.stop()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+
+    def "confirm RxHttpClient can be closed"() {
+        given:
+        def client = RxHttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.close()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+}


### PR DESCRIPTION
The delegation for close, start and stop were missing.

Fixes #50