### PR TITLE
Fix BOM generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,6 @@ micronautTestVersion=3.0.3
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
 
-rxJava2Version=2.2.21
-
 title=Micronaut RxJava 2
 projectDesc=Integration between Micronaut and RxJava 2
 projectUrl=https://micronaut.io

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+managed-rxjava2 = "2.2.21"
+
+[libraries]
+managed-rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "managed-rxjava2" }

--- a/rxjava2-bom/build.gradle
+++ b/rxjava2-bom/build.gradle
@@ -1,9 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-
-dependencies {
-    constraints {
-        api("io.reactivex.rxjava2:rxjava:$rxJava2Version")
-    }
-}

--- a/rxjava2-http-server-netty/build.gradle
+++ b/rxjava2-http-server-netty/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     api "io.micronaut:micronaut-runtime"
     api "io.micronaut:micronaut-http-server-netty"
-    api "io.reactivex.rxjava2:rxjava:$rxJava2Version"
+    api libs.managed.rxjava2
 }

--- a/rxjava2/build.gradle
+++ b/rxjava2/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     annotationProcessor "io.micronaut:micronaut-graal"
 
     api "io.micronaut:micronaut-runtime"
-    api "io.reactivex.rxjava2:rxjava:$rxJava2Version"
+    api libs.managed.rxjava2
 }


### PR DESCRIPTION
By using a version declared in a catalog, we will consistently
generate a `rxjava2` entry in the generated catalog. This is
important because when `micronaut-core` will import the catalog,
it will _inline_ entries of this catalog, so that an entry
for `mn.rxjava2` exists.

This fixes the error seen at https://github.com/micronaut-projects/micronaut-tracing/runs/6651567986?check_suite_focus=true#step:8:63