### PR TITLE
fix: use MutableConversionService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "io.micronaut.build.internal.docs"
-    id "io.micronaut.build.internal.dependency-updates"
     id "io.micronaut.build.internal.quality-reporting"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectGroup=io.micronaut.rxjava2
 
 micronautDocsVersion=2.0.0
 micronautVersion=4.0.0-SNAPSHOT
-micronautTestVersion=3.5.0
+micronautTestVersion=4.0.0-SNAPSHOT
 
 groovyVersion=4.0.6
 spockVersion=2.3-groovy-4.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 managed-rxjava2 = "2.2.21"
+groovy = '4.0.6'
 
 [libraries]
 managed-rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "managed-rxjava2" }
+groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "groovy" }

--- a/rxjava2-http-client/build.gradle
+++ b/rxjava2-http-client/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     testAnnotationProcessor mn.micronaut.validation
     testAnnotationProcessor mn.micronaut.inject.java
 
-    testImplementation mn.micronaut.retry
     testImplementation mn.micronaut.validation
     testImplementation mn.micronaut.jackson.databind
     testImplementation libs.groovy.json

--- a/rxjava2-http-client/build.gradle
+++ b/rxjava2-http-client/build.gradle
@@ -3,15 +3,17 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-graal"
+    annotationProcessor mn.micronaut.graal
 
     api project(":rxjava2")
-    api "io.micronaut:micronaut-http-client"
+    api mn.micronaut.http.client
 
-    testAnnotationProcessor "io.micronaut:micronaut-validation"
-    testAnnotationProcessor "io.micronaut:micronaut-inject-java"
+    testAnnotationProcessor mn.micronaut.validation
+    testAnnotationProcessor mn.micronaut.inject.java
 
-    testImplementation "io.micronaut:micronaut-validation"
-    testImplementation 'org.codehaus.groovy:groovy-json'
+    testImplementation mn.micronaut.retry
+    testImplementation mn.micronaut.validation
+    testImplementation mn.micronaut.jackson.databind
+    testImplementation libs.groovy.json
     testImplementation project(":rxjava2-http-server-netty")
 }

--- a/rxjava2-http-client/src/test/groovy/io/micronaut/rxjava2/http/client/RxJavaFallbackSpec.groovy
+++ b/rxjava2-http-client/src/test/groovy/io/micronaut/rxjava2/http/client/RxJavaFallbackSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Fallback
+import io.micronaut.retry.annotation.Recoverable
 import io.micronaut.runtime.server.EmbeddedServer
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -99,6 +100,7 @@ class RxJavaFallbackSpec extends Specification{
     }
 
     @Requires(property = 'spec.name', value = 'RxJavaFallbackSpec')
+    @Recoverable(api = BookApi.class)
     @Client('/rxjava/fallback/books')
     static interface BookClient extends BookApi {
     }

--- a/rxjava2-http-server-netty/build.gradle
+++ b/rxjava2-http-server-netty/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    api "io.micronaut:micronaut-runtime"
-    api "io.micronaut:micronaut-http-server-netty"
+    api mn.micronaut.http.server.netty
     api libs.managed.rxjava2
 }

--- a/rxjava2-http-server-netty/src/main/java/io/micronaut/rxjava2/server/upload/binders/RxJava2NettyBinderRegistrar.java
+++ b/rxjava2-http-server-netty/src/main/java/io/micronaut/rxjava2/server/upload/binders/RxJava2NettyBinderRegistrar.java
@@ -30,7 +30,7 @@ import jakarta.inject.Singleton;
 @Internal
 @Requires(classes = Flowable.class)
 class RxJava2NettyBinderRegistrar implements BeanCreatedEventListener<RequestBinderRegistry> {
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final HttpContentProcessorResolver httpContentProcessorResolver;
 
     /**
@@ -40,7 +40,7 @@ class RxJava2NettyBinderRegistrar implements BeanCreatedEventListener<RequestBin
      * @param httpContentProcessorResolver The processor resolver
      */
     RxJava2NettyBinderRegistrar(
-            @Nullable ConversionService<?> conversionService,
+            @Nullable ConversionService conversionService,
             HttpContentProcessorResolver httpContentProcessorResolver) {
         this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
         this.httpContentProcessorResolver = httpContentProcessorResolver;

--- a/rxjava2/build.gradle
+++ b/rxjava2/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-graal"
+    annotationProcessor mn.micronaut.graal
 
-    api "io.micronaut:micronaut-runtime"
+    api mn.micronaut.retry
     api libs.managed.rxjava2
 }

--- a/rxjava2/src/main/java/io/micronaut/rxjava2/converters/RxJavaConverterRegistrar.java
+++ b/rxjava2/src/main/java/io/micronaut/rxjava2/converters/RxJavaConverterRegistrar.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.rxjava2.converters;
 
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.reactivex.BackpressureStrategy;
@@ -25,7 +23,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 
 /**
@@ -34,9 +31,6 @@ import org.reactivestreams.Publisher;
  * @author graemerocher
  * @since 1.0
  */
-@Singleton
-@Requires(classes = Flowable.class)
-@BootstrapContextCompatible
 public class RxJavaConverterRegistrar implements TypeConverterRegistrar {
 
     @SuppressWarnings("unchecked")

--- a/rxjava2/src/main/java/io/micronaut/rxjava2/converters/RxJavaConverterRegistrar.java
+++ b/rxjava2/src/main/java/io/micronaut/rxjava2/converters/RxJavaConverterRegistrar.java
@@ -17,7 +17,7 @@ package io.micronaut.rxjava2.converters;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Completable;
@@ -41,7 +41,7 @@ public class RxJavaConverterRegistrar implements TypeConverterRegistrar {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
 
         // Completable
         conversionService.addConverter(Completable.class, Publisher.class, Completable::toFlowable);

--- a/rxjava2/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/rxjava2/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.rxjava2.converters.RxJavaConverterRegistrar


### PR DESCRIPTION
this fails with: 

https://ge.micronaut.io/s/emykbxlucpa5i


```
	
  	
  ConversionService.SHARED.convert(from, target).isPresent()	
  |                 |      |       |     |       |	
  |                 |      |       |     |       false	
  |                 |      |       |     class io.reactivex.Observable	
  |                 |      |       <io.reactivex.internal.operators.completable.CompletableEmpty@1642968c>	
  |                 |      Optional.empty	
  |                 <io.micronaut.core.convert.DefaultMutableConversionService@1c3b221f typeConverters=[io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@e202bc02:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$451/0x0000000800dc8f50@238280df, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@6a350a3:io.micronaut.core.convert.converters.MultiValuesConverterFactory$MapToMultiValuesConverter@182fd26b, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@a927a927:io.micronaut.http.converters.SharedHttpConvertersRegistrar$$Lambda$487/0x0000000800dd1008@5dc120ab, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@e3d16ad0:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$444/0x0000000800dc8000@49c4118b, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@88615d60:io.micronaut.core.convert.converters.MultiValuesConverterFactory$MultiValuesToObjectConverter@7ef7f414, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@24642f62:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$431/0x0000000800dc5ef0@182dcd2b, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@6d426d44:io.micronaut.runtime.converters.time.TimeConverterRegistrar$$Lambda$499/0x0000000800dd2a08@4c3d72fd, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@9748b743:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$475/0x0000000800dcc428@259c6ab8, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@fd2f8422:io.micronaut.runtime.converters.time.TimeConverterRegistrar$$Lambda$499/0x0000000800dd2a08@640a6d4b, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@ecee0efa:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$435/0x0000000800dc67b8@1238a074, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@8f928686:io.micronaut.core.convert.converters.MultiValuesConverterFactory$ObjectToMultiValuesConverter@35b58254, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@75dcd1c8:io.micronaut.runtime.converters.time.TimeConverterRegistrar$$Lambda$493/0x0000000800dd1d30@73baf7f0, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@65adabbb:io.micronaut.runtime.converters.time.TimeConverterRegistrar$$Lambda$493/0x0000000800dd1d30@446dacf9, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@aba16cb6:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$480/0x0000000800dcd138@13018f00, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@925f4947:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$446/0x0000000800dc8460@abf1816, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@5c3f2227:io.micronaut.inject.annotation.AnnotationConvertersRegistrar$$Lambda$504/0x0000000800dd3540@2e1e7bc6, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@df455ef:io.micronaut.core.convert.format.ReadableBytesTypeConverter@7bd1098, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@e973906d:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$430/0x0000000800dc5cc0@185bf6e0, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@2e569f49:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$471/0x0000000800dcbb50@6a562255, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@e11ddb3d:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$437/0x0000000800dc6c18@374ba492, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@c414fc35:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$427/0x0000000800dc5630@581d5b33, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@a75dc07c:io.micronaut.core.convert.TypeConverter$$Lambda$417/0x0000000800dc3328@1f365a26, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@69764e55:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$422/0x0000000800dc4938@44a9971f, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@70386b1b:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$468/0x0000000800dcb4b0@2e2cd42c, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@929cc4bf:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$474/0x0000000800dcc1f0@1cdad619, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@fc09882d:io.micronaut.core.convert.DefaultMutableConversionService$$Lambda$457/0x0000000800dc9c80@319058ce, io.micronaut.core.convert.DefaultMutableConversionService$ConvertiblePair@61846dae:io.micronaut.core.convert.TypeConverter$$Lambda$417/0x0000000800dc3328@3909308c, io.micronaut.core.convert.D…	
  interface io.micronaut.core.convert.ConversionService	
      at io.micronaut.rxjava2.converters.ReactiveTypeConversionSpec.test converting reactive type #from.getClass().getSimpleName() to #target(ReactiveTypeConversionSpec.groovy:38)	
```