### PR TITLE
test: add JAX-RS/serde test suite for rxjava2 (12154)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,22 @@ managed-rxjava2 = "2.2.21"
 
 groovy = '4.0.29'
 spock = "2.3-groovy-4.0"
+junit-platform = "1.11.4"
 
 micronaut = "4.10.8"
 micronaut-docs = "3.0.0"
 micronaut-test = "4.9.0"
 micronaut-validation = "4.11.0"
+micronaut-jaxrs = "4.9.2"
+micronaut-serialization = "2.15.5"
 
 [libraries]
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 managed-rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "managed-rxjava2" }
+managed-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 groovy-json = { module = "org.apache.groovy:groovy-json", version.ref = "groovy" }
+spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
+micronaut-jaxrs = { module = "io.micronaut.jaxrs:micronaut-jaxrs-bom", version.ref = "micronaut-jaxrs" }
+micronaut-serialization = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serialization" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include 'rxjava2'
 include 'rxjava2-bom'
 include 'rxjava2-http-client'
 include 'rxjava2-http-server-netty'
+include 'test-suite-rxjava2-jaxrs-serialization'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
@@ -22,4 +23,6 @@ micronautBuild {
     useStandardizedProjectNames = true
     importMicronautCatalog()
     importMicronautCatalog("micronaut-validation")
+    importMicronautCatalog("micronaut-jaxrs")
+    importMicronautCatalog("micronaut-serialization")
 }

--- a/test-suite-rxjava2-jaxrs-serialization/build.gradle
+++ b/test-suite-rxjava2-jaxrs-serialization/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java-library'
+    id 'groovy'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testAnnotationProcessor mn.micronaut.inject.java
+    testAnnotationProcessor mnJaxrs.micronaut.jaxrs.processor
+    testAnnotationProcessor mnSerde.micronaut.serde.processor
+
+    testCompileOnly mn.micronaut.inject.groovy
+
+    testImplementation libs.spock.core
+
+    testRuntimeOnly libs.managed.junit.platform.launcher
+
+    testImplementation projects.micronautRxjava2
+    testImplementation projects.micronautRxjava2HttpServerNetty
+    testImplementation mn.micronaut.http.client
+    testImplementation mnJaxrs.micronaut.jaxrs.server
+    testImplementation mnSerde.micronaut.serde.jackson
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}

--- a/test-suite-rxjava2-jaxrs-serialization/src/test/groovy/io/micronaut/rxjava2/jaxrs/ObservableJaxRsSerializationSpec.groovy
+++ b/test-suite-rxjava2-jaxrs-serialization/src/test/groovy/io/micronaut/rxjava2/jaxrs/ObservableJaxRsSerializationSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rxjava2.jaxrs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.PendingFeature
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ObservableJaxRsSerializationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ObservableJaxRsSerializationSpec'
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+
+    @PendingFeature(reason = 'micronaut-core#12154')
+    void "rxjava2 Observable response should be serialized (micronaut-core#12154)"() {
+        when:
+        String body = client.toBlocking().retrieve(HttpRequest.GET('/pets/observable'))
+
+        then:
+        body.contains('Fluffy')
+    }
+}

--- a/test-suite-rxjava2-jaxrs-serialization/src/test/java/io/micronaut/rxjava2/jaxrs/NameDto.java
+++ b/test-suite-rxjava2-jaxrs-serialization/src/test/java/io/micronaut/rxjava2/jaxrs/NameDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rxjava2.jaxrs;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class NameDto {
+    private final String name;
+
+    public NameDto(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/test-suite-rxjava2-jaxrs-serialization/src/test/java/io/micronaut/rxjava2/jaxrs/PetResource.java
+++ b/test-suite-rxjava2-jaxrs-serialization/src/test/java/io/micronaut/rxjava2/jaxrs/PetResource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.rxjava2.jaxrs;
+
+import io.reactivex.Observable;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+@Singleton
+@Path("/pets")
+public class PetResource {
+
+    @GET
+    @Path("observable")
+    @Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+    public Observable<NameDto> allObservable() {
+        return Observable.just(new NameDto("Fluffy"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `test-suite-rxjava2-jaxrs-serialization` (non-published) with JAX-RS + Micronaut Serialization dependencies.
- Add a reproducer for micronaut-core#12154 (Observable return type) and mark it `@PendingFeature`.

## Notes
In 4.9.x context propagation can wrap reactive return values (e.g. `ReactivePropagation$1`). In micronaut-jaxrs the response filter rewrites the body `Argument` to the wrapper runtime class, so serde attempts to serialize the wrapper instead of the emitted DTO.